### PR TITLE
change clarity to mango for lich

### DIFF
--- a/bots/BotLib/hero_lich.lua
+++ b/bots/BotLib/hero_lich.lua
@@ -55,7 +55,7 @@ sRoleItemsBuyList['pos_4'] = {
 sRoleItemsBuyList['pos_5'] = {
     "item_double_tango",
     "item_faerie_fire",
-	"item_enchanted_mango",
+    "item_enchanted_mango",
     "item_blood_grenade",
 
     "item_boots",

--- a/bots/BotLib/hero_lich.lua
+++ b/bots/BotLib/hero_lich.lua
@@ -55,7 +55,7 @@ sRoleItemsBuyList['pos_4'] = {
 sRoleItemsBuyList['pos_5'] = {
     "item_double_tango",
     "item_faerie_fire",
-    "item_clarity",
+	"item_enchanted_mango",
     "item_blood_grenade",
 
     "item_boots",


### PR DESCRIPTION
lich can't regen mana, mango is a better alternative for this