### PR TITLE
fixing not taking custom sound settings if set to false

### DIFF
--- a/bots/FretBots/Settings.lua
+++ b/bots/FretBots/Settings.lua
@@ -114,9 +114,13 @@ local chatCommands =
 	'speak', 'sp',      -- speak specific language
 
 }
-
-Settings.isPlaySounds = Customize.Fretbots.Play_Sounds or Settings.isPlaySounds
-Settings.isPlayerDeathSound = Customize.Fretbots.Player_Death_Sound or Settings.isPlayerDeathSound
+if Customize and Customize.Fretbots then
+    Settings.isPlaySounds = Customize.Fretbots.Play_Sounds
+    Settings.isPlayerDeathSound = Customize.Fretbots.Player_Death_Sound
+else
+    Settings.isPlaySounds =  Settings.isPlaySounds
+    Settings.isPlayerDeathSound = Settings.isPlayerDeathSound
+end
 
 function Settings:CalculateDifficultyScale(difficulty)
 	-- no argument implies default, do nothing


### PR DESCRIPTION
if Customize.Fretbots.Play_Sounds or Customize.Fretbots.Player_Death_Sound is set to false, defaultsettings will always be chosen instead.