### PR TITLE
fix(bot): fix target stuttering, tower diving, teamfight gank fatigue…

### DIFF
--- a/bots/FunLib/aba_push.lua
+++ b/bots/FunLib/aba_push.lua
@@ -155,7 +155,7 @@ function ____exports.GetPushDesireHelper(bot, lane)
     if enemiesAtAncient >= 1 then
         return BotModeDesire.ExtraLow
     end
-    if #alliesHere <= 1 and gameState.aliveEnemyCount >= 3 then
+    if #alliesHere <= 1 and gameState.aliveEnemyCount >= 3 and 5 - gameState.aliveEnemyCount < 2 then
         return BotModeDesire.None
     end
     if gameState.aliveAllyCount <= gameState.aliveEnemyCount - 2 then
@@ -247,6 +247,18 @@ function ____exports.GetPushDesireHelper(bot, lane)
     local enemyAverageLevel = jmz.GetAverageLevel(true)
     local levelAdvantage = gameState.averageLevel - enemyAverageLevel
     local hasSignificantAdvantage = networthAdvantage > 15000 or levelAdvantage > 2
+    local enemyDeadCount = 5 - gameState.aliveEnemyCount
+    local powerplayBonus = 0
+    if enemyDeadCount >= 2 then
+        powerplayBonus = RemapValClamped(
+            enemyDeadCount,
+            2,
+            4,
+            0.4,
+            1
+        )
+        nMaxDesire = 0.95
+    end
     if #alliesHere < #enemiesHere and #alliesHere <= eAliveCount - 1 and aAliveCount < eAliveCount then
         if hasSignificantAdvantage and #alliesHere >= #enemiesHere - 1 then
             nMaxDesire = math.min(nMaxDesire, 0.6)
@@ -285,7 +297,7 @@ function ____exports.GetPushDesireHelper(bot, lane)
     local pushLane = ____exports.WhichLaneToPush(bot, lane)
     local isCurrentLanePushLane = pushLane == lane
     if not jmz.IsCore(bot) and isCurrentLanePushLane or jmz.IsCore(bot) and (jmz.IsLateGame() and isCurrentLanePushLane or isMidOrEarlyGame) then
-        local allowNumbers = eAliveCount == 0 or aAliveCoreCount >= eAliveCoreCount or aAliveCoreCount >= 1 and aAliveCount >= eAliveCount + 2 or networthAdvantage > 8000 and aAliveCount >= eAliveCount - 1 or levelAdvantage > 2 and aAliveCount >= eAliveCount - 1
+        local allowNumbers = eAliveCount == 0 or enemyDeadCount >= 2 or aAliveCoreCount >= eAliveCoreCount or aAliveCoreCount >= 1 and aAliveCount >= eAliveCount + 2 or networthAdvantage > 8000 and aAliveCount >= eAliveCount - 1 or levelAdvantage > 2 and aAliveCount >= eAliveCount - 1
         if allowNumbers then
             if gameState.hasAegis then
                 nPushDesire = nPushDesire + 0.3
@@ -321,9 +333,9 @@ function ____exports.GetPushDesireHelper(bot, lane)
                 nPushDesire = nPushDesire + groupBonus
             end
             return RemapValClamped(
-                nPushDesire * jmz.GetHP(bot),
+                (nPushDesire + powerplayBonus) * jmz.GetHP(bot),
                 0,
-                1,
+                2,
                 0,
                 nMaxDesire
             )
@@ -556,7 +568,7 @@ else
 end
 ____Customize_1.ThinkLess = ____Customize_Enable_0
 pingTimeDelta = 5
-StartToPushTime = 16 * 60
+StartToPushTime = 10 * 60
 BOT_MODE_DESIRE_EXTRA_LOW = 0.02
 hEnemyAncient = nil
 PUSH_CACHE_TTL = 0.5
@@ -814,24 +826,24 @@ function ____exports.PushThink(bot, lane)
     local towerDistanceToFountain = bTowerNearby and GetUnitToLocationDistance(nEnemyTowers[1], vTeamFountain) or 0
     for ____, creep in ipairs(nCreeps) do
         do
-            local __continue120
+            local __continue121
             repeat
                 if not jmz.IsValid(creep) or not jmz.CanBeAttacked(creep) then
-                    __continue120 = true
+                    __continue121 = true
                     break
                 end
                 if jmz.IsTormentor(creep) or jmz.IsRoshan(creep) then
-                    __continue120 = true
+                    __continue121 = true
                     break
                 end
                 if bTowerNearby and GetUnitToLocationDistance(creep, vTeamFountain) >= towerDistanceToFountain then
-                    __continue120 = true
+                    __continue121 = true
                     break
                 end
                 bot:Action_AttackUnit(creep, true)
                 return
             until true
-            if not __continue120 then
+            if not __continue121 then
                 break
             end
         end

--- a/bots/FunLib/jmz_func.lua
+++ b/bots/FunLib/jmz_func.lua
@@ -4724,6 +4724,17 @@ function J.WeAreStronger(bot, nRadius)
 		end
 	end
 
+	local nEnemyTowers = bot:GetNearbyTowers(600, true)
+	if J.IsValidBuilding(nEnemyTowers[1]) then
+		if nEnemyTowers[1]:HasModifier('modifier_fountain_glyph') then
+			local power = #nEnemyTowers * (math.sqrt(Max(0, nEnemyTowers[1]:GetAttackDamage() * nEnemyTowers[1]:GetAttackSpeed() * 5.0 * 2)))
+			enemyPower = enemyPower + power
+		else
+			local power = #nEnemyTowers * (math.sqrt(Max(0, nEnemyTowers[1]:GetAttackDamage() * nEnemyTowers[1]:GetAttackSpeed() * 5.0)))
+			enemyPower = enemyPower + power
+		end
+	end
+
 	if not J.IsEarlyGame() and J.IsInTeamFight(bot, 1600) and #tAllyHeroes >= #tEnemyHeroes then
 		local vTeamFightLocation = J.GetTeamFightLocation(bot)
 		if vTeamFightLocation ~= nil and (J.IsHumanInLoc(vTeamFightLocation, 1200) or #tAllyHeroes > #tEnemyHeroes) then
@@ -6541,9 +6552,19 @@ function J.CheckBotIdleState()
 					bot:Action_ClearActions(true);
 
 					-- Should send it to most desire farming lane, if in laning or send it to desire push lane.
-					local frontLoc = GetLaneFrontLocation(GetTeam(), bot:GetAssignedLane(), 0);
+					local pushLane, pushDesire = J.GetMostPushLaneDesire()
+					local defendLane, defendDesire = J.GetMostDefendLaneDesire()
+					local targetLane = bot:GetAssignedLane()
+
+					if defendLane ~= nil and defendDesire ~= nil and defendDesire > 0.4 then
+						targetLane = defendLane
+					elseif pushLane ~= nil and pushDesire ~= nil and pushDesire > 0.4 then
+						targetLane = pushLane
+					end
+
+					local frontLoc = GetLaneFrontLocation(GetTeam(), targetLane, 0)
 					bot:ActionQueue_AttackMove(frontLoc)
-					print('[ERROR] Relocating the idle bot: '..botName..'. Sending it to the lane# it was originally assigned: '..tostring(bot:GetAssignedLane()))
+					print('[ERROR] Relocating the idle bot: '..botName..'. Sending it to target lane: '..tostring(targetLane))
 				else
 					print('Bot '..botName..' is in idle state for unknown reasons. N/A.')
 				end

--- a/bots/FunLib/override_generic/mode_attack_generic.lua
+++ b/bots/FunLib/override_generic/mode_attack_generic.lua
@@ -23,6 +23,9 @@ local Generic = BotsInit.CreateGeneric()
 
 function Generic.OnStart() end
 function Generic.OnEnd()
+	botTarget.unit = nil
+	botTarget.location = 0
+	botTarget.id = -1
 	botTarget.fogChase = false
 	helpAlly.should = false
 end
@@ -33,6 +36,14 @@ function Generic.GetDesire()
 	or bot:HasModifier('modifier_fountain_fury_swipes_damage_increase')
 	then
 		return BOT_MODE_DESIRE_NONE
+	end
+
+	if botTarget.unit ~= nil then
+		if not IsValid(botTarget.unit) or not botTarget.unit:IsAlive() then
+			bot.lastKillTime = DotaTime()
+			botTarget.unit = nil
+			botTarget.id = -1
+		end
 	end
 
 	if bClearMode then bClearMode = false return 0 end
@@ -135,12 +146,16 @@ function Generic.GetDesire()
 			end
 			local nEnemyTowersNear = bot:GetNearbyTowers(1200, true)
 			if J.IsValidBuilding(nEnemyTowersNear[1]) then
-				fEnemyDamage = fEnemyDamage + #nEnemyTowersNear * nEnemyTowersNear[1]:GetAttackDamage()
+				local towerAS = nEnemyTowersNear[1]:GetAttackSpeed() or 1.0
+				fEnemyDamage = fEnemyDamage + #nEnemyTowersNear * nEnemyTowersNear[1]:GetAttackDamage() * towerAS * 3.0
 			end
 
 			local b1 = (bWeAreStronger and fAllyDamage >= enemyHero:GetHealth() * 0.2 and botHealth > fEnemyDamage * 1.15)
 			local b2 = (#nInRangeAlly >= #nInRangeEnemy and fAllyDamage >= enemyHero:GetHealth() * 0.3 and botHealth > fEnemyDamage * 1.15)
 			local b3 = (vTeamFightLocation ~= nil and (((GetUnitToLocationDistance(bot, vTeamFightLocation) - botAttackRange) / bot:GetCurrentMovementSpeed()) <= 10.0))
+			if b3 and bot.lastKillTime ~= nil and DotaTime() - bot.lastKillTime < 8.0 then
+				b3 = false
+			end
 
 			if b1 or b2 or b3 then
 				local dist = GetUnitToUnitDistance(bot, enemyHero)
@@ -209,6 +224,7 @@ function Generic.GetDesire()
 						if #tAllyHeroes_real >= #tEnemyHeroes_real2 or bWeAreStronger then
 							botTarget.fogChase = true
 							botTarget.location = dInfo.location
+							botTarget.time_since_seen = dInfo.time_since_seen
 							return GetActualDesire(BOT_MODE_DESIRE_VERYHIGH)
 						end
 					end
@@ -386,12 +402,14 @@ function Generic.Think()
 	-- Fog-of-war chase
 	if botTarget.fogChase then
 		local vLastSeen = botTarget.location
+		local timeSeen = botTarget.time_since_seen or 1.0
+		local offset = 500 + (timeSeen - 0.5) * 500
 		local vDirs = {
-			vLastSeen + Vector(700, 0),
-			vLastSeen + Vector(-700, 0),
-			vLastSeen + Vector(0, 700),
-			vLastSeen + Vector(0, -700),
-			vLastSeen + Vector(700, 700),
+			vLastSeen + Vector(offset, 0),
+			vLastSeen + Vector(-offset, 0),
+			vLastSeen + Vector(0, offset),
+			vLastSeen + Vector(0, -offset),
+			vLastSeen + Vector(offset, offset),
 		}
 		local vBest, vBestScore = nil, 0
 		for _, loc in ipairs(vDirs) do

--- a/bots/mode_team_roam_generic.lua
+++ b/bots/mode_team_roam_generic.lua
@@ -105,6 +105,32 @@ function GetDesireHelper()
         IsSupport  = not IsHeroCore
     end
 
+    -- Success/failure tracking for Help Ally
+    if bot.helpAllyActive then
+        if DotaTime() - bot.helpAllyStartTime > 20.0 then
+            bot.helpAllyActive = false
+            bot.lastHelpAllyTime = DotaTime()
+            bot.helpAllyCooldown = 90.0
+        else
+            local targetDead = false
+            if bot.helpAllyTargetUnit ~= nil and (not J.IsValidHero(bot.helpAllyTargetUnit) or not bot.helpAllyTargetUnit:IsAlive()) then
+                targetDead = true
+            end
+            if targetDead then
+                bot.helpAllyActive = false
+                bot.lastHelpAllyTime = DotaTime()
+                bot.helpAllyCooldown = 30.0
+            end
+        end
+    end
+
+    local onCooldown = false
+    if bot.lastHelpAllyTime ~= nil and bot.helpAllyCooldown ~= nil then
+        if DotaTime() - bot.lastHelpAllyTime < bot.helpAllyCooldown then
+            onCooldown = true
+        end
+    end
+
     ItemOpsDesire()
 
     local target
@@ -118,8 +144,15 @@ function GetDesireHelper()
     nearbyAllies = J.GetAlliesNearLoc(bot:GetLocation(), 2200)
     nearbyEnemies = J.GetEnemiesNearLoc(bot:GetLocation(), 2000)
 
-    target, ShouldHelpAlly = ConsiderHelpAlly()
+    target, ShouldHelpAlly = nil, false
+    if not onCooldown then
+        target, ShouldHelpAlly = ConsiderHelpAlly()
+    end
     if ShouldHelpAlly then
+        bot.helpAllyActive = true
+        bot.helpAllyStartTime = DotaTime()
+        bot.helpAllyTargetUnit = target
+        bot.helpAllyCooldown = nil
         SetStickyTarget(target)
         targetUnit = target
         return RemapValClamped(J.GetHP(bot), 0, 0.6, BOT_MODE_DESIRE_NONE, 0.98)
@@ -287,6 +320,8 @@ function OnEnd()
     towerTime = 0
     towerCreepMode = false
     PickedItem = nil
+    targetUnit = nil
+    bot.helpAllyActive = false
 end
 
 -- ==============================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,7 +1426,7 @@
             "version": "5.5.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
             "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/typescript/bots/FunLib/aba_push.ts
+++ b/typescript/bots/FunLib/aba_push.ts
@@ -12,7 +12,7 @@ Customize.ThinkLess = Customize.Enable ? Customize.ThinkLess : 1;
  * (kept from Lua; comments preserved)
  */
 const pingTimeDelta = 5;
-const StartToPushTime = 16 * 60; // after X mins, start considering to push.
+const StartToPushTime = 10 * 60; // after X mins, start considering to push.
 const BOT_MODE_DESIRE_EXTRA_LOW = 0.02;
 
 /** Module-scoped state (cache-ish). Keep small and intentional. */
@@ -286,8 +286,8 @@ export function GetPushDesireHelper(bot: Unit, lane: Lane): BotModeDesire {
     if (enemiesAtAncient >= 1) return BotModeDesire.ExtraLow;
 
     // --- Push safety gates ---
-    // Never push alone when 3+ enemies alive
-    if (alliesHere.length <= 1 && gameState.aliveEnemyCount >= 3) {
+    // Never push alone when 3+ enemies alive, unless we are in a powerplay window (2+ enemies dead)
+    if (alliesHere.length <= 1 && gameState.aliveEnemyCount >= 3 && (5 - gameState.aliveEnemyCount) < 2) {
         return BotModeDesire.None;
     }
     // Never push with 2+ hero count disadvantage
@@ -407,6 +407,14 @@ export function GetPushDesireHelper(bot: Unit, lane: Lane): BotModeDesire {
     const levelAdvantage = gameState.averageLevel - enemyAverageLevel;
     const hasSignificantAdvantage = networthAdvantage > 15000 || levelAdvantage > 2;
 
+    // POWERPLAY: jika >=2 enemy dead, boost desire + unlock cap
+    const enemyDeadCount = 5 - gameState.aliveEnemyCount;
+    let powerplayBonus = 0;
+    if (enemyDeadCount >= 2) {
+        powerplayBonus = RemapValClamped(enemyDeadCount, 2, 4, 0.4, 1.0);
+        nMaxDesire = 0.95; // override cap saat powerplay
+    }
+
     // If outnumbered in *local* area, desire is very low (avoid feed)
     // But be more lenient when team has significant advantages
     if (alliesHere.length < enemiesHere.length && alliesHere.length <= eAliveCount - 1 && aAliveCount < eAliveCount) {
@@ -458,6 +466,7 @@ export function GetPushDesireHelper(bot: Unit, lane: Lane): BotModeDesire {
         // Allow pushes more easily when we have significant advantages
         const allowNumbers =
             eAliveCount === 0 ||
+            enemyDeadCount >= 2 || // Powerplay override
             aAliveCoreCount >= eAliveCoreCount ||
             (aAliveCoreCount >= 1 && aAliveCount >= eAliveCount + 2) ||
             // New: Allow pushes with networth advantage even if slightly outnumbered
@@ -490,7 +499,7 @@ export function GetPushDesireHelper(bot: Unit, lane: Lane): BotModeDesire {
                 nPushDesire = nPushDesire + groupBonus;
             }
 
-            return RemapValClamped(nPushDesire * jmz.GetHP(bot), 0, 1, 0, nMaxDesire) as BotModeDesire;
+            return RemapValClamped((nPushDesire + powerplayBonus) * jmz.GetHP(bot), 0, 2, 0, nMaxDesire) as BotModeDesire;
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@ b4a@^1.6.4:
   resolved "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz"
   integrity sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==
 
-bare-events@*, bare-events@^2.2.0, bare-events@^2.5.4:
+bare-events@^2.2.0, bare-events@^2.5.4:
   version "2.6.1"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz"
   integrity sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==
@@ -252,7 +252,7 @@ degenerator@^5.0.0:
     escodegen "^2.1.0"
     esprima "^4.0.1"
 
-devtools-protocol@*, devtools-protocol@0.0.1475386:
+devtools-protocol@0.0.1475386:
   version "0.0.1475386"
   resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz"
   integrity sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==
@@ -840,7 +840,7 @@ typescript-to-lua@^1.26.2:
     resolve "^1.15.1"
     source-map "^0.7.3"
 
-typescript@^5.5.4, typescript@>=4.9.5, typescript@5.5.2:
+typescript@^5.5.4:
   version "5.5.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz"
   integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==


### PR DESCRIPTION
## Description

This Pull Request addresses 5 major behavioral issues identified during community gameplay matches, focusing on bot decision-making logic, engagement safety under enemy towers, roaming fatigue, idle stagnation, and lack of push response after winning fights (no powerplay).

### Issues Fixed & Root Causes Addressed

1. **Bot Patrol / Stuttering after Kills (Issue 1)**
* **Fix:** Cleared target states in `OnEnd` inside `mode_attack_generic.lua`.
* Scaled Fog of War chase radius progressively based on `time_since_seen`.
* Added a post-kill teamfight location engagement downgrade to prevent auto-returning to stale fight locations.


2. **Tower Diving / Over-aggressive Engagements (Issue 2)**
* **Fix:** Fixed `J.WeAreStronger` to symmetrically factor in enemy tower power.
* Scaled tower damage calculations in `mode_attack` using `AttackSpeed * 3.0` to match the hero DPS evaluation window.


3. **Excessive / Constant Roaming and Ganking (Issue 3)**
* **Fix:** Implemented an active gank/help-ally cooldown and success/failure tracker in `mode_team_roam_generic.lua` to prevent endless group roaming.


4. **Stagnation / Converging to Assigned Lanes in Mid-Late Game (Issue 4)**
* **Fix:** Upgraded the idle relocator in `J.CheckBotIdleState` to dynamically redirect idle bots to lanes that need defending or pushing based on global lane desires.


5. **No Push Action After Kills / No Powerplay Advantage (Issue 5)**
* **Fix:** Added a `powerplayBonus` inside `aba_push.ts` to override maximum desire caps and boost push scores when enemy heroes are dead.
* Reduced human-opponent push restriction time threshold from 16 to 10 minutes.