### PR TITLE
fix: prevent bots from denying non-creep entities (e.g. Tidehunter fish)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ temp_build/
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
+.codeartsdoer
 
 # Local History for Visual Studio Code
 .history/

--- a/bots/mode_laning_generic.lua
+++ b/bots/mode_laning_generic.lua
@@ -164,6 +164,7 @@ function GetBestDenyCreep(hCreepList)
 		and J.GetHP(creep) < 0.49
 		and J.CanBeAttacked(creep)
 		and creep:GetHealth() <= attackDamage
+		and string.find(creep:GetUnitName(), 'npc_dota_creep_')
 		then
 			return creep
 		end

--- a/bots/mode_roam_generic.lua
+++ b/bots/mode_roam_generic.lua
@@ -1565,7 +1565,7 @@ function ConsiderGeneralRoamingInConditions()
 			bot:Action_AttackUnit(nInCloseRangeAlly[2], true)
 		else
 			local allyCreeps = bot:GetNearbyCreeps(1000, false)
-			if #allyCreeps >= 1 and J.IsValid(allyCreeps[1]) then
+			if #allyCreeps >= 1 and J.IsValid(allyCreeps[1]) and string.find(allyCreeps[1]:GetUnitName(), 'npc_dota_creep_') then
 				bot:Action_AttackUnit(allyCreeps[1], true)
 			end
 		end

--- a/bots/mode_team_roam_generic.lua
+++ b/bots/mode_team_roam_generic.lua
@@ -714,14 +714,15 @@ function X.CarryFindTarget()
 			local nTwoHitDenyCreeps = bot:GetNearbyCreeps(nAttackRange +120, false);
 			for _,creep in pairs(nTwoHitDenyCreeps)
 			do
-				if X.CanBeAttacked(creep)
-				and creep:GetHealth()/creep:GetMaxHealth() < 0.5
-				and X.IsLastHitCreep(creep,denyDamage *2)
-				and ( not X.IsLastHitCreep(creep,denyDamage *1.2) or #nEnemyLaneCreep == 0 )
-				and not X.IsOthersTarget(creep)
-				and not J.IsTormentor(creep)
-				and not J.IsRoshan(creep)
-				then
+			if X.CanBeAttacked(creep)
+			and creep:GetHealth()/creep:GetMaxHealth() < 0.5
+			and X.IsLastHitCreep(creep,denyDamage *2)
+			and ( not X.IsLastHitCreep(creep,denyDamage *1.2) or #nEnemyLaneCreep == 0 )
+			and not X.IsOthersTarget(creep)
+			and not J.IsTormentor(creep)
+			and not J.IsRoshan(creep)
+			and string.find(creep:GetUnitName(), 'npc_dota_creep_')
+			then
 					return creep,BOT_MODE_DESIRE_ABSOLUTE;
 				end
 			end
@@ -978,6 +979,7 @@ function X.GetNearbyLastHitCreep(ignorAlly, bEnemy, nDamage, nRadius, bot)
 	do
 		if X.CanBeAttacked(nCreep) and nCreep:GetHealth() < ( nDamage + 256 )
 		and ( ignorAlly or not X.IsAllysTarget(nCreep) )
+		and ( bEnemy or string.find(nCreep:GetUnitName(), 'npc_dota_creep_') )
 		then
 		
 			local nAttackProDelayTime = J.GetAttackProDelayTime(bot,nCreep) ;


### PR DESCRIPTION
## Problem

Tidehunter's innate ability **Leviathan's Catch** spawns a fish entity when an enemy hero dies under his debuffs. The bot's deny/attack logic treats this fish as a deniable lane creep because:

1. The game engine classifies the fish as a lane creep entity, so `GetNearbyLaneCreeps()` returns it
2. The fish has low HP, satisfying all deny conditions
3. The bot attacks (denies) the fish instead of picking it up

Three attack paths were affected:
- `mode_laning_generic.lua` - `GetBestDenyCreep()` laning deny
- `mode_team_roam_generic.lua` - `X.GetNearbyLastHitCreep()` roam deny + two-hit deny
- `mode_roam_generic.lua` - tower aggro drop path

## Fix

Added a unit name filter `string.find(unit:GetUnitName(), 'npc_dota_creep_')` to all deny/attack paths that target allied units. Only actual lane creeps (names starting with `npc_dota_creep_`) are targeted for denial. This safely excludes non-creep entities like Tidehunter's fish.

## Files changed

- `bots/mode_laning_generic.lua` -- line 167
- `bots/mode_team_roam_generic.lua` -- lines 982, 724
- `bots/mode_roam_generic.lua` -- line 1568